### PR TITLE
For Custom Data Generation the examples must be required

### DIFF
--- a/app/client/src/pages/DataGenerator/Examples.tsx
+++ b/app/client/src/pages/DataGenerator/Examples.tsx
@@ -1,3 +1,4 @@
+import isEmpty from 'lodash/isEmpty';
 import { useEffect, useRef } from 'react';
 import { Button, Form, Modal, Space, Skeleton, Table, Tooltip, Typography, Flex } from 'antd';
 import EditIcon from '@mui/icons-material/Edit';
@@ -8,6 +9,8 @@ import { useFetchExamples } from '../../api/api';
 import TooltipIcon from '../../components/TooltipIcon';
 import PCModalContent from './PCModalContent';
 import { QuestionSolution, WorkflowType } from './types';
+import { useWizardCtx } from './utils';
+import { isEqual } from 'lodash';
 
 const { Title } = Typography;
 const Container = styled.div`
@@ -32,7 +35,18 @@ const MAX_EXAMPLES = 5;
 
 const Examples = () => {
     const form = Form.useFormInstance();
-    console.log('-------Examples', form.getFieldsValue());
+    const { setIsStepValid } = useWizardCtx();
+    const _values = Form.useWatch('examples', form);
+
+    useEffect (() => {
+        const values = form.getFieldsValue();
+        if (isEmpty(values.examples)) {
+            setIsStepValid(false);
+        } else if (!isEmpty(values?.examples)) {
+            setIsStepValid(true);
+        }
+    }, [_values]); 
+
     const columns = [
         {
             title: 'Prompts',
@@ -134,13 +148,6 @@ const Examples = () => {
         form.setFieldValue('examples', examples.examples)
     }
     const rowLimitReached = form.getFieldValue('examples')?.length === MAX_EXAMPLES;
-    const workflow_type = form.getFieldValue('workflow_type');
-    console.log('workflow_type', workflow_type);
-
-    const isCustomWorkflow = workflow_type === WorkflowType.CUSTOM_DATA_GENERATION;
-    if (isCustomWorkflow) {
-        columns.shift();
-    }
 
     return (
         <Container>

--- a/app/client/src/pages/DataGenerator/hooks.ts
+++ b/app/client/src/pages/DataGenerator/hooks.ts
@@ -89,6 +89,22 @@ export const fetchCustomPrompt = async (params: any) => {
     }
 }
 
+export const listModels = async (params: any) => {
+    const resp = await fetch(`${BASE_API_URL}/model/model_ID`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(params),
+    });
+    if (resp.status !== 200) {
+        const error = await resp.json();
+        throw new Error(error.message || error.detail);
+    }
+    const body = await resp.json();
+    return body;
+}
+
 export const listFilesByPath = async (params: any) => {
     const resp = await fetch(`${BASE_API_URL}/get_project_files`, {
         method: 'POST',


### PR DESCRIPTION
This PR resolves the custom examples issue, the custom examples returns an empty list and the next button should be disabled till user enters new examples.