### PR TITLE
UI Changes for Freeforms Workflow

### DIFF
--- a/app/client/src/pages/DataGenerator/CustomPromptButton.tsx
+++ b/app/client/src/pages/DataGenerator/CustomPromptButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Form, Input, Modal, notification } from "antd";
+import { Button, Col, Flex, Form, Input, Modal, notification, Row } from "antd";
 import { useEffect, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import styled from "styled-components";
@@ -10,12 +10,13 @@ interface Props {
     use_case: string;
     inference_type: string;
     caii_endpoint: string;
+    example_path?: string | null;
     setPrompt: (prompt: string) => void
 }
 
 export const StyledTextArea = styled(Input.TextArea)`
     margin-bottom: 10px !important;
-    min-height: 275px !important;
+    height:  100% !important;
     margin-bottom: 10px !important;
     padding: 15px 20px !important;
 `;
@@ -29,6 +30,7 @@ const StyledModal = styled(Modal)`
     .ant-modal-body {
       padding-top: 0;
       min-height: 70vh;
+      yoverflow-y: auto;
     }
   }
   // .ant-modal-content {
@@ -39,7 +41,12 @@ const StyledModal = styled(Modal)`
   //  }
 `        
 
-const CustomPromptButton: React.FC<Props> = ({ model_id, inference_type, caii_endpoint, use_case, setPrompt }) => {
+const StyledFlex = styled(Flex)`
+  flex-direction: row-reverse;
+`;
+
+
+const CustomPromptButton: React.FC<Props> = ({ model_id, inference_type, caii_endpoint, use_case, example_path, setPrompt }) => {
   const [form] = Form.useForm();
   const [showModal, setShowModal] = useState(false);
 
@@ -69,7 +76,8 @@ const CustomPromptButton: React.FC<Props> = ({ model_id, inference_type, caii_en
         inference_type,
         caii_endpoint,
         custom_prompt,
-        use_case
+        use_case,
+        example_path
       })
     } catch(e) {
       console.error(e);
@@ -90,9 +98,18 @@ const CustomPromptButton: React.FC<Props> = ({ model_id, inference_type, caii_en
             <StyledModal
               visible={showModal}
               okText={`Generate`}
-              title={`Generate Cutom Prompt`}
-              onCancel={() => setShowModal(false)}
-              onOk={() => onFinish()}
+              title={`Generate Custom Prompt`}
+              footer={
+                <Row>
+                  <Col sm={12} />    
+                  <Col sm={12}>
+                    <StyledFlex key="footer-right">
+                      <Button type="primary" style={{ marginLeft: '12px' }} disabled={mutation.isPending} onClick={() => onFinish()}>{'Generate Custom Prompt'}</Button>
+                      <Button disabled={mutation.isPending} style={{ marginLeft: '12px' }} onClick={() => setShowModal(false)}>{'Cancel'}</Button>
+                    </StyledFlex>
+                  </Col>
+                </Row>
+              }
             >
                 <Form 
                     form={form} 
@@ -103,7 +120,9 @@ const CustomPromptButton: React.FC<Props> = ({ model_id, inference_type, caii_en
                     disabled={mutation.isPending}
                 >
                     {mutation.isPending && 
-                      <Loading />
+                      <Flex justify='center' align='center' style={{ marginBottom: '16px' }}>
+                        <Loading />
+                      </Flex>
                     }
 
                     <Form.Item
@@ -113,7 +132,9 @@ const CustomPromptButton: React.FC<Props> = ({ model_id, inference_type, caii_en
                         labelCol={{ span: 24 }}
                         wrapperCol={{ span: 24 }}
                     >
-                        <StyledTextArea 
+                        <StyledTextArea
+                            disabled={mutation.isPending} 
+                            rows={15}
                             autoSize 
                             placeholder={'Enter instructions for a custom prompt'}
                         />

--- a/app/client/src/pages/DataGenerator/DataGenerator.tsx
+++ b/app/client/src/pages/DataGenerator/DataGenerator.tsx
@@ -68,14 +68,14 @@ const steps: WizardStepConfig[] = [
         required: true,
     },
     {
-        title: 'Prompt',
-        key: DataGenWizardSteps.PROMPT,
-        content: <Prompt/>,
-    },
-    {
         title: 'Examples',
         key: DataGenWizardSteps.EXAMPLES,
         content: <Examples/>
+    },
+    {
+        title: 'Prompt',
+        key: DataGenWizardSteps.PROMPT,
+        content: <Prompt/>,
     },
     {
         title: 'Summary',

--- a/app/client/src/pages/DataGenerator/Finish.tsx
+++ b/app/client/src/pages/DataGenerator/Finish.tsx
@@ -8,7 +8,7 @@ import AssessmentIcon from '@mui/icons-material/Assessment';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import GradingIcon from '@mui/icons-material/Grading';
 import ModelTrainingIcon from '@mui/icons-material/ModelTraining';
-import { Avatar, Button, Card, Divider, Flex, Form, List, Modal, Result, Spin, Tabs, Table, Typography, FormInstance } from 'antd';
+import { Avatar, Button, Card, Divider, Flex, Form, List, Modal, Result, Spin, Tabs, Table, Typography, FormInstance, Popover } from 'antd';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -206,9 +206,17 @@ const Finish = () => {
 
         topicTabs = genDatasetResp?.results && Object.keys(genDatasetResp.results).map((topic, i) => {
             return ({
-            key: `${topic}-${i}`,
-            label: <Typography.Text style={{ maxWidth: '300px' }} ellipsis={true}>{topic}</Typography.Text>,
-            value: topic,
+            key: `topic-${i}`,
+            label: (
+            <Popover content={topic} placement="right" trigger="hover" overlayStyle={{
+                width: "50vw",
+                maxHeight: '50vh',
+                overflowY: 'auto'
+              }}>
+                <Typography.Text style={{ maxWidth: '300px' }} ellipsis={true}>{topic}</Typography.Text>
+            </Popover>)
+            ,
+            value: topic.replace(/\n/g, ' '),
             children: workflow_type !== WorkflowType.FREE_FORM_DATA_GENERATION ?
             <TopicsTable formData={genDatasetResp} topic={topic} /> :
             // <FreeFormTable data={get(genDatasetResp, `results.${topic}`)} />

--- a/app/client/src/pages/DataGenerator/Prompt.tsx
+++ b/app/client/src/pages/DataGenerator/Prompt.tsx
@@ -15,6 +15,7 @@ import { useWizardCtx } from './utils';
 import { useDatasetSize, useGetPromptByUseCase } from './hooks';
 import CustomPromptButton from './CustomPromptButton';
 import get from 'lodash/get';
+import TextArea from 'antd/es/input/TextArea';
 
 const { Title } = Typography;
 
@@ -153,7 +154,8 @@ const Prompt = () => {
         
     }, [selectedTopics, numQuestions, datasetSize]);
 
-    const onTopicTextChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const onTopicTextChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+        console.log('onTopicTextChange:', event.target.value);
         setCustomTopic(event.target.value);
     };
 
@@ -163,6 +165,7 @@ const Prompt = () => {
 
     const addItem = (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
         e.preventDefault();
+        console.log('Adding custom topic:', customTopic);
         if (!customTopic || items.includes(customTopic)) {
             return; // Prevent adding duplicate or empty topics
         }
@@ -237,6 +240,7 @@ const Prompt = () => {
                                 inference_type={inference_type}
                                 caii_endpoint={caii_endpoint}
                                 use_case={useCase}
+                                example_path={form.getFieldValue('example_path') || null}
                                 setPrompt={setPrompt}
                             />
                         }
@@ -315,9 +319,10 @@ const Prompt = () => {
                                                 ]}
                                             >
                                                 <Space.Compact block>
-                                                    <Input
+                                                    <TextArea
                                                         disabled={selectedTopics?.length === MAX_SEED_INSTRUCTIONS}
                                                         placeholder="Enter custom seed instruction"
+                                                        rows={4}
                                                         ref={customTopicRef}
                                                         value={customTopic}
                                                         onChange={onTopicTextChange}
@@ -330,6 +335,7 @@ const Prompt = () => {
                                                         }
                                                     >
                                                         <Button
+                                                            style={{ marginLeft: '12px' }}
                                                             disabled={items.includes(customTopic) ||
                                                                 selectedTopics?.length === MAX_SEED_INSTRUCTIONS ||
                                                                 customTopic.length === 0}

--- a/app/client/src/pages/DataGenerator/Success.tsx
+++ b/app/client/src/pages/DataGenerator/Success.tsx
@@ -4,7 +4,7 @@ import AssessmentIcon from '@mui/icons-material/Assessment';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import GradingIcon from '@mui/icons-material/Grading';
 import ModelTrainingIcon from '@mui/icons-material/ModelTraining';
-import { Avatar, Button, Card, Divider, Flex, List, Modal, Tabs, Table, Typography } from 'antd';
+import { Avatar, Button, Card, Divider, Flex, List, Modal, Tabs, Table, Typography, Popover } from 'antd';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -12,7 +12,7 @@ import PCModalContent from './PCModalContent'
 import { GenDatasetResponse, QuestionSolution } from './types';
 import { getFilesURL } from '../Evaluator/util';
 
-const { Title } = Typography;
+const { Text, Title } = Typography;
 
 const TabsContainer = styled(Card)`
     .ant-card-body {
@@ -88,9 +88,9 @@ interface SuccessProps {
 }
 const Success: FC<SuccessProps> = ({ formData, isDemo = true }) => {
     const topicTabs = formData?.results && Object.keys(formData.results).map((topic, i) => ({
-        key: `${topic}-${i}`,
-        label: topic,
-        value: topic,
+        key: `tab-${i}`,
+        label: <Popover content={topic}><Text>{topic}</Text></Popover>,
+        value: topic.replace(/\n/g, ' '),
         children: <TopicsTable formData={formData} topic={topic} />
     }));
     const nextStepsList = [


### PR DESCRIPTION
This PR contains changes for following items:

- Examples & Prompt for Dataset Generator Wizard is swapped
- For the Seed Instructions users can enter multi line seeds and new line will not be removed
- For the Success view of the Dataset Generation the Topics tabbed/table view will have the popover to display the whole seed instruction
- For the custom prompt generation if the examples file has been uploaded will be used to generate the prompt
- Minor improvements for the Generate Custom Prompt Modal

<img width="1341" alt="Screenshot 2025-05-28 at 7 37 16 PM" src="https://github.com/user-attachments/assets/ac5912da-a79a-442c-a587-d671a4eea245" />
<img width="1322" alt="Screenshot 2025-05-28 at 7 37 26 PM" src="https://github.com/user-attachments/assets/070497fe-dbdf-4cfb-9644-6294935643c7" />
<img width="1237" alt="Screenshot 2025-05-28 at 8 57 03 PM" src="https://github.com/user-attachments/assets/f5e375b2-d606-43f9-bd10-2fcad011b1b2" />
