### PR TITLE
upgrade database process separated as a subprocess within same endpoi…

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1420,13 +1420,22 @@ async def perform_upgrade():
 
         # 2. Database migrations
         try:
-            db_success, db_message = await alembic_manager.handle_database_upgrade()
-            if db_success:
-                db_upgraded = True
-                messages.append(db_message)
-            else:
-                messages.append(f"Database upgrade failed: {db_message}")
-                raise HTTPException(status_code=500, detail=db_message)
+            # In your upgrade endpoint, you can add this debug line:
+            print(f"Current working directory: {os.getcwd()}")
+            print(f"Alembic.ini exists: {os.path.exists('alembic.ini')}")
+            print("--- Starting database migration via external script ---")
+            # Use `uv run` to ensure the script runs within the project's virtual environment
+            # This is more robust than just calling 'python'
+            result = subprocess.run(
+                ["uv", "run", "python", "run_migrations.py"],
+                capture_output=True,
+                text=True,
+                check=True  # This will raise CalledProcessError on failure
+            )
+            
+            print(result.stdout) # Log the output from the script
+            db_upgraded = True
+            messages.append("Database migration check completed successfully.")
         except Exception as e:
             messages.append(f"Database migration failed: {str(e)}")
             raise HTTPException(status_code=500, detail=str(e))

--- a/run_migrations.py
+++ b/run_migrations.py
@@ -1,0 +1,33 @@
+import asyncio
+import sys
+from pathlib import Path
+
+# Ensure the 'app' directory is in the Python path
+ROOT_DIR = Path(__file__).parent
+APP_DIR = ROOT_DIR / "app"
+sys.path.append(str(ROOT_DIR))
+
+from app.migrations.alembic_manager import AlembicMigrationManager
+
+async def main():
+    """
+    Initializes the migration manager and runs the database upgrade.
+    This will always use the latest code from disk.
+    """
+    print("--- Running dedicated migration script ---")
+    # Assumes your DB file is named metadata.db in the root
+    db_path = str(ROOT_DIR / "metadata.db")
+    alembic_manager = AlembicMigrationManager(db_path)
+    
+    success, message = await alembic_manager.handle_database_upgrade()
+    
+    if not success:
+        print(f"Migration Error: {message}")
+        # Exit with a non-zero status code to indicate failure
+        sys.exit(1)
+    
+    print(f"Migration Success: {message}")
+    print("--- Migration script finished ---")
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
- Database migration is now running as a subprocess within the upgrade endpoint.
- This enables code to be directly picked from disk rather than memory for upgrade.